### PR TITLE
Add MERN skeleton with authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Alternativelife MERN App
+
+This repository contains a basic MERN stack skeleton for the Alternativelife website. The application features registration and login with JWT authentication and a protected dashboard that contains a placeholder astrology tool, saved reports and a profile page.
+
+## Structure
+
+- `server/` – Express.js backend with MongoDB models and routes
+- `client/` – React frontend bootstrapped with Vite
+
+## Environment variables
+
+Create a `.env` file inside `server/` based on `.env.example`:
+
+```
+PORT=5000
+MONGO_URI=mongodb://localhost:27017/alternativelife
+JWT_SECRET=supersecret
+```
+
+## Running locally
+
+Install dependencies for both `server` and `client` and start them separately. The server runs on `localhost:5000` and the client on `localhost:5173` by default.

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Alternativelife</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "alternativelife-client",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "vite"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.17.0",
+    "axios": "^1.5.0"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0"
+  }
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './pages/App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
+);

--- a/client/src/pages/App.jsx
+++ b/client/src/pages/App.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import Login from './Login.jsx';
+import Register from './Register.jsx';
+import Dashboard from './Dashboard.jsx';
+
+export default function App() {
+  return (
+    <Routes>
+      <Route path="/login" element={<Login />} />
+      <Route path="/register" element={<Register />} />
+      <Route path="/*" element={<Dashboard />} />
+    </Routes>
+  );
+}

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Routes, Route, Link, useNavigate } from 'react-router-dom';
+import AstroTool from './dashboard/AstroTool.jsx';
+import Reports from './dashboard/Reports.jsx';
+import Profile from './dashboard/Profile.jsx';
+
+export default function Dashboard() {
+  const navigate = useNavigate();
+  const logout = () => {
+    localStorage.removeItem('token');
+    navigate('/login');
+  };
+  return (
+    <div>
+      <nav className="p-4 bg-gray-800 text-white flex gap-4">
+        <Link to="/">Astro Tool</Link>
+        <Link to="/reports">Reports</Link>
+        <Link to="/profile">Profile</Link>
+        <button onClick={logout} className="ml-auto">Logout</button>
+      </nav>
+      <Routes>
+        <Route path="/" element={<AstroTool />} />
+        <Route path="/reports" element={<Reports />} />
+        <Route path="/profile" element={<Profile />} />
+      </Routes>
+    </div>
+  );
+}

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    const res = await axios.post('/api/auth/login', { email, password });
+    localStorage.setItem('token', res.data.token);
+    navigate('/');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 max-w-sm mx-auto">
+      <h1 className="text-xl mb-2">Login</h1>
+      <input className="border mb-2 w-full" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+      <input className="border mb-2 w-full" type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+      <button className="bg-blue-500 text-white px-4 py-2" type="submit">Login</button>
+    </form>
+  );
+}

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+
+export default function Register() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    const res = await axios.post('/api/auth/register', { name, email, password });
+    localStorage.setItem('token', res.data.token);
+    navigate('/');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 max-w-sm mx-auto">
+      <h1 className="text-xl mb-2">Register</h1>
+      <input className="border mb-2 w-full" value={name} onChange={e => setName(e.target.value)} placeholder="Name" />
+      <input className="border mb-2 w-full" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+      <input className="border mb-2 w-full" type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+      <button className="bg-blue-500 text-white px-4 py-2" type="submit">Register</button>
+    </form>
+  );
+}

--- a/client/src/pages/dashboard/AstroTool.jsx
+++ b/client/src/pages/dashboard/AstroTool.jsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+export default function AstroTool() {
+  const [name, setName] = useState('');
+  const [date, setDate] = useState('');
+  const [time, setTime] = useState('');
+  const [place, setPlace] = useState('');
+  const [result, setResult] = useState(null);
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    const token = localStorage.getItem('token');
+    const res = await axios.post('/api/astro/calculate', {
+      type: 'natal',
+      person1Data: { name, date, time, place }
+    }, { headers: { Authorization: `Bearer ${token}` } });
+    setResult(res.data);
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl mb-2">Astro Tool</h1>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input className="border w-full" value={name} onChange={e => setName(e.target.value)} placeholder="Name" />
+        <input className="border w-full" value={date} onChange={e => setDate(e.target.value)} placeholder="Date" />
+        <input className="border w-full" value={time} onChange={e => setTime(e.target.value)} placeholder="Time" />
+        <input className="border w-full" value={place} onChange={e => setPlace(e.target.value)} placeholder="Place" />
+        <button className="bg-blue-500 text-white px-4 py-2" type="submit">Calculate</button>
+      </form>
+      {result && <pre className="mt-4 bg-gray-100 p-2">{JSON.stringify(result, null, 2)}</pre>}
+    </div>
+  );
+}

--- a/client/src/pages/dashboard/Profile.jsx
+++ b/client/src/pages/dashboard/Profile.jsx
@@ -1,0 +1,33 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+
+export default function Profile() {
+  const [form, setForm] = useState({ name: '', email: '', birthData: { date: '', time: '', location: { displayName: '', lat: '', lon: '' } } });
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    axios.get('/api/user/me', { headers: { Authorization: `Bearer ${token}` } })
+      .then(res => setForm(res.data));
+  }, []);
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    const token = localStorage.getItem('token');
+    const { name, email, birthData } = form;
+    await axios.put('/api/user/profile', { name, email, birthData }, { headers: { Authorization: `Bearer ${token}` } });
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl mb-2">Profile</h1>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input className="border w-full" value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} placeholder="Name" />
+        <input className="border w-full" value={form.email} onChange={e => setForm({ ...form, email: e.target.value })} placeholder="Email" />
+        <input className="border w-full" value={form.birthData.date} onChange={e => setForm({ ...form, birthData: { ...form.birthData, date: e.target.value } })} placeholder="Birth Date" />
+        <input className="border w-full" value={form.birthData.time} onChange={e => setForm({ ...form, birthData: { ...form.birthData, time: e.target.value } })} placeholder="Birth Time" />
+        <input className="border w-full" value={form.birthData.location.displayName} onChange={e => setForm({ ...form, birthData: { ...form.birthData, location: { ...form.birthData.location, displayName: e.target.value } } })} placeholder="Birth Place" />
+        <button className="bg-blue-500 text-white px-4 py-2" type="submit">Save</button>
+      </form>
+    </div>
+  );
+}

--- a/client/src/pages/dashboard/Reports.jsx
+++ b/client/src/pages/dashboard/Reports.jsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+export default function Reports() {
+  const [reports, setReports] = useState([]);
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    axios.get('/api/reports', { headers: { Authorization: `Bearer ${token}` } })
+      .then(res => setReports(res.data));
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl mb-2">Reports</h1>
+      <ul>
+        {reports.map(r => (
+          <li key={r._id} className="border-b py-2">
+            {r.type} - {new Date(r.createdAt).toLocaleString()}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,3 @@
+PORT=5000
+MONGO_URI=mongodb://localhost:27017/alternativelife
+JWT_SECRET=supersecret

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "alternativelife-server",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "node src/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "mongoose": "^7.0.0",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.0",
+    "dotenv": "^16.0.0",
+    "cors": "^2.8.5"
+  }
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,0 +1,28 @@
+import express from 'express';
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import cors from 'cors';
+
+import authRoutes from './routes/auth.js';
+import userRoutes from './routes/user.js';
+import astroRoutes from './routes/astro.js';
+import reportRoutes from './routes/report.js';
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.use('/api/auth', authRoutes);
+app.use('/api/user', userRoutes);
+app.use('/api/astro', astroRoutes);
+app.use('/api/reports', reportRoutes);
+
+const PORT = process.env.PORT || 5000;
+
+mongoose.connect(process.env.MONGO_URI || '', { useNewUrlParser: true, useUnifiedTopology: true })
+  .then(() => {
+    app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+  })
+  .catch(err => console.error(err));

--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -1,0 +1,15 @@
+import jwt from 'jsonwebtoken';
+import User from '../models/User.js';
+
+export default async function auth(req, res, next) {
+  const token = req.headers.authorization && req.headers.authorization.split(' ')[1];
+  if (!token) return res.status(401).json({ message: 'No token provided' });
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = await User.findById(decoded.id);
+    if (!req.user) return res.status(401).json({ message: 'Invalid token' });
+    next();
+  } catch (err) {
+    res.status(401).json({ message: 'Unauthorized' });
+  }
+}

--- a/server/src/models/HoroscopeReport.js
+++ b/server/src/models/HoroscopeReport.js
@@ -1,0 +1,22 @@
+import mongoose from 'mongoose';
+
+const reportSchema = new mongoose.Schema({
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  type: { type: String, enum: ['natal', 'synastry'], required: true },
+  person1Data: {
+    name: String,
+    date: String,
+    time: String,
+    place: String
+  },
+  person2Data: {
+    name: String,
+    date: String,
+    time: String,
+    place: String
+  },
+  reportContent: { type: Object },
+  createdAt: { type: Date, default: Date.now }
+});
+
+export default mongoose.model('HoroscopeReport', reportSchema);

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -1,0 +1,23 @@
+import mongoose from 'mongoose';
+
+const locationSchema = new mongoose.Schema({
+  displayName: String,
+  lat: Number,
+  lon: Number
+}, { _id: false });
+
+const birthDataSchema = new mongoose.Schema({
+  date: String,
+  time: String,
+  location: locationSchema
+}, { _id: false });
+
+const userSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  email: { type: String, required: true, unique: true },
+  password: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+  birthData: birthDataSchema
+});
+
+export default mongoose.model('User', userSchema);

--- a/server/src/routes/astro.js
+++ b/server/src/routes/astro.js
@@ -1,0 +1,27 @@
+import express from 'express';
+import auth from '../middleware/auth.js';
+import HoroscopeReport from '../models/HoroscopeReport.js';
+
+const router = express.Router();
+
+router.post('/calculate', auth, async (req, res) => {
+  try {
+    // In real implementation, call Bloom API with birth data here
+    const { type, person1Data, person2Data } = req.body;
+    const dummyReport = { message: 'Bloom API response placeholder' };
+
+    const report = await HoroscopeReport.create({
+      userId: req.user._id,
+      type,
+      person1Data,
+      person2Data,
+      reportContent: dummyReport
+    });
+
+    res.json(report);
+  } catch {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+export default router;

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -1,0 +1,36 @@
+import express from 'express';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import User from '../models/User.js';
+
+const router = express.Router();
+
+router.post('/register', async (req, res) => {
+  try {
+    const { name, email, password } = req.body;
+    const existing = await User.findOne({ email });
+    if (existing) return res.status(400).json({ message: 'Email already in use' });
+    const hashed = await bcrypt.hash(password, 10);
+    const user = await User.create({ name, email, password: hashed });
+    const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, { expiresIn: '1d' });
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  try {
+    const { email, password } = req.body;
+    const user = await User.findOne({ email });
+    if (!user) return res.status(400).json({ message: 'Invalid credentials' });
+    const isMatch = await bcrypt.compare(password, user.password);
+    if (!isMatch) return res.status(400).json({ message: 'Invalid credentials' });
+    const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, { expiresIn: '1d' });
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+export default router;

--- a/server/src/routes/report.js
+++ b/server/src/routes/report.js
@@ -1,0 +1,12 @@
+import express from 'express';
+import auth from '../middleware/auth.js';
+import HoroscopeReport from '../models/HoroscopeReport.js';
+
+const router = express.Router();
+
+router.get('/', auth, async (req, res) => {
+  const reports = await HoroscopeReport.find({ userId: req.user._id }).sort({ createdAt: -1 });
+  res.json(reports);
+});
+
+export default router;

--- a/server/src/routes/user.js
+++ b/server/src/routes/user.js
@@ -1,0 +1,25 @@
+import express from 'express';
+import auth from '../middleware/auth.js';
+import bcrypt from "bcryptjs";
+
+const router = express.Router();
+
+router.get('/me', auth, (req, res) => {
+  res.json(req.user);
+});
+
+router.put('/profile', auth, async (req, res) => {
+  try {
+    const { name, email, password, birthData } = req.body;
+    if (name) req.user.name = name;
+    if (email) req.user.email = email;
+    if (password) req.user.password = await bcrypt.hash(password, 10);
+    if (birthData) req.user.birthData = birthData;
+    await req.user.save();
+    res.json(req.user);
+  } catch {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add Express server with JWT auth and MongoDB models
- add React client with login, register, and a protected dashboard
- include example environment file and setup docs

## Testing
- `npm test` in `server` *(fails: Missing script)*
- `npm test` in `client` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b5b23ac14832ea6a041c4f03d8a41